### PR TITLE
Rename `post` to `slug` in StaticMan.

### DIFF
--- a/gatsby/_data/comments/comment1526127508295.json
+++ b/gatsby/_data/comments/comment1526127508295.json
@@ -1,1 +1,11 @@
-{"_id":"93737c40-55de-11e8-9ca2-03d586cce74d","post":"/introduction-to-gatsby-data-flow","name":"skube","email":"0a577c41cde30752036471c926d94515","message":"Love your writing style and simple explanations (esp. tl;dr).  Would be great to see a few more full examples.","date":1526127508,"timestamp":1526127508,"tags":[]}
+{
+  "_id": "93737c40-55de-11e8-9ca2-03d586cce74d",
+  "slug": "/introduction-to-gatsby-data-flow",
+  "name": "skube",
+  "email": "0a577c41cde30752036471c926d94515",
+  "message":
+    "Love your writing style and simple explanations (esp. tl;dr).  Would be great to see a few more full examples.",
+  "date": 1526127508,
+  "timestamp": 1526127508,
+  "tags": []
+}

--- a/gatsby/_data/comments/comment1526127923748.json
+++ b/gatsby/_data/comments/comment1526127923748.json
@@ -1,1 +1,11 @@
-{"_id":"8b135c90-55df-11e8-9ca2-03d586cce74d","post":"/getting-started-with-gatsby-v2","name":"skube","email":"0a577c41cde30752036471c926d94515","message":"So if `gatsby-plugin-sass` is an example of a plugin whose @next tag is out of date, should one just:\r\n `yarn add gatsby-plugin-sass` (instead of appending `@next`)?","date":1526127923,"timestamp":1526127923,"tags":[]}
+{
+  "_id": "8b135c90-55df-11e8-9ca2-03d586cce74d",
+  "slug": "/getting-started-with-gatsby-v2",
+  "name": "skube",
+  "email": "0a577c41cde30752036471c926d94515",
+  "message":
+    "So if `gatsby-plugin-sass` is an example of a plugin whose @next tag is out of date, should one just:\r\n `yarn add gatsby-plugin-sass` (instead of appending `@next`)?",
+  "date": 1526127923,
+  "timestamp": 1526127923,
+  "tags": []
+}

--- a/gatsby/src/components/CommentsScene/components/CommentForm.js
+++ b/gatsby/src/components/CommentsScene/components/CommentForm.js
@@ -47,7 +47,6 @@ const CommentForm = ({ postId }) => {
         value="https://www.gatsbycentral.com/comments/success"
       />
       <input name="options[slug]" type="hidden" value={postId} />
-      <input name="fields[post]" type="hidden" value={postId} />
       <label>
         <Input name="fields[name]" type="text" placeholder="Name" required />
       </label>

--- a/gatsby/src/templates/post.js
+++ b/gatsby/src/templates/post.js
@@ -45,7 +45,7 @@ export const pageQuery = graphql`
       }
     }
     allCommentsJson(
-      filter: { post: { eq: $path } }
+      filter: { slug: { eq: $path } }
       sort: { fields: [date], order: ASC }
     ) {
       edges {

--- a/staticman.yml
+++ b/staticman.yml
@@ -7,7 +7,7 @@ comments:
   #
   # Names of the fields the form is allowed to submit. If a field that is
   # not here is part of the request, an error will be thrown.
-  allowedFields: ["name", "email", "url", "message", "post"]
+  allowedFields: ["name", "email", "url", "message"]
 
   # (*) REQUIRED
   #


### PR DESCRIPTION
I noticed that the staticman comment form has 2 fields `slug` and `post`. I think `slug` is the one we should use, it's not a user editable "field". But it doesn't end up in our PRs. There's some kind of bug with StaticMan right now.

https://github.com/eduardoboucas/staticman/issues/176

Maybe that's why you added the `post` field? I renamed `post` to `slug` in the existing comments and I changed the queries, etc so it all uses `slug`. However, I guess if we merge this, new comments will be broken. But new comments are broken right now anyway, they come in with an empty `message` field. :-(

What do you think we should do?